### PR TITLE
Typo "There was an order updating the page order."

### DIFF
--- a/includes/class-np-handler-sort.php
+++ b/includes/class-np-handler-sort.php
@@ -35,7 +35,7 @@ class NP_SortHandler extends NP_BaseHandler {
 		if ( $order ){
 			$this->response = array('status' => 'success', 'message' => __('Page order successfully updated.','nestedpages') );
 		} else {
-			$this->response = array('status'=>'error', 'message'=> __('There was an order updating the page order.','nestedpages') );
+			$this->response = array('status'=>'error', 'message'=> __('There was an error updating the page order.','nestedpages') );
 		}
 	}
 


### PR DESCRIPTION
Replacing by "There was an **_error**_ updating the page order."
