### PR TITLE
Check user capability before deleting a post

### DIFF
--- a/app/Entities/Post/PostRepository.php
+++ b/app/Entities/Post/PostRepository.php
@@ -122,7 +122,8 @@ class PostRepository {
 	{
 		$posts_q = new \WP_Query(array('post_type'=>$post_type, 'post_status'=>'trash', 'posts_per_page'=>-1));
 		if ( $posts_q->have_posts() ) : while ( $posts_q->have_posts() ) : $posts_q->the_post();
-			wp_delete_post(get_the_id(), true);
+			if( current_user_can( 'delete_' . $post_type, get_the_id() ) )
+				wp_delete_post(get_the_id(), true);
 		endwhile; endif; wp_reset_postdata();
 		return true;
 	}


### PR DESCRIPTION
Users with custom roles can delete pages without permission by using "Empty Trash".