### PR TITLE
Ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/*
 .DS_Store
 Thumbs.db
+composer.lock


### PR DESCRIPTION
composer.lock should be ignored in PHP libraries including Wordpress plugins