### PR TITLE
Plugin directory constant definition fixed and applied to main require_once() declaration

### DIFF
--- a/nestedpages.php
+++ b/nestedpages.php
@@ -47,7 +47,7 @@ function nestedpages_check_versions( $wp = '3.9', $php = '5.3.2' ) {
 }
 
 if( !class_exists('Bootstrap') ) :
-    define('NESTEDPAGES_DIR', __FILE__);
+    define('NESTEDPAGES_DIR', __DIR__);
     nestedpages_check_versions();
     require_once('vendor/autoload.php');
     require_once('app/NestedPages.php');

--- a/nestedpages.php
+++ b/nestedpages.php
@@ -49,7 +49,7 @@ function nestedpages_check_versions( $wp = '3.9', $php = '5.3.2' ) {
 if( !class_exists('Bootstrap') ) :
     define('NESTEDPAGES_DIR', __DIR__);
     nestedpages_check_versions();
-    require_once('vendor/autoload.php');
-    require_once('app/NestedPages.php');
+    require_once(NESTEDPAGES_DIR . '/vendor/autoload.php');
+    require_once(NESTEDPAGES_DIR . '/app/NestedPages.php');
     NestedPages::init();
 endif;


### PR DESCRIPTION
Hi there, changing this constant definition fixed a bug with a customised version of Bedrock at https://roots.io/bedrock/ that I inherited for a project.

cheers
Ian

Fatal error: Class 'NestedPages\FrontEndBootstrap' not found 