### PR TITLE
Fix for syncMenu firing on every menu update, even when option disabled.

### DIFF
--- a/app/Entities/NavMenu/NavMenuActions.php
+++ b/app/Entities/NavMenu/NavMenuActions.php
@@ -1,8 +1,10 @@
 <?php 
+// Replace app/Entities/NavMenu/NavMenuActions.php with this:
 
 namespace NestedPages\Entities\NavMenu;
 
 use NestedPages\Entities\NavMenu\NavMenuSyncMenu;
+use NestedPages\Config\SettingsRepository;
 /**
 * Hook into WP actions for necessary tasks related to nav menus
 */
@@ -19,9 +21,13 @@ class NavMenuActions
 	*/
 	public function syncMenu($menu_id, $menu_data = null)
 	{
+		$settings = new SettingsRepository;
+		$nested_pages_menu_id = get_option('nestedpages_menu');
 		// Core calls action twice. Only want it to run once. 
 		// Don't need it to run in wp_update_nav_menu_object function
-		if ( $menu_data == null ) $sync = new NavMenuSyncMenu($menu_id);
+		if ( !$settings->menusDisabled() && $menu_id == $nested_pages_menu_id && $menu_data == null ){
+			$sync = new NavMenuSyncMenu($menu_id);
+		}
 	}
 
 }

--- a/app/Entities/NavMenu/NavMenuSync.php
+++ b/app/Entities/NavMenu/NavMenuSync.php
@@ -24,7 +24,7 @@ abstract class NavMenuSync
 
 	public function __construct()
 	{
-		if ( get_option('nestedpages_menusync') !== 'sync' ) return;
+		if ( get_option('nestedpages_menusync') !== 'sync' || get_option('nestedpages_disable_menu' ) === 'true' ) return;
 		$this->nav_menu_repo = new NavMenuRepository;
 		$this->setMenuID();
 	}

--- a/app/Entities/NavMenu/NavMenuSyncListing.php
+++ b/app/Entities/NavMenu/NavMenuSyncListing.php
@@ -70,10 +70,12 @@ class NavMenuSyncListing extends NavMenuSync
 	{
 		// Get the Menu Item
 		$query_type = ( $this->post->type == 'np-redirect' ) ? 'xfn' : 'object_id';
-		$menu_item_id = $this->nav_menu_repo->getMenuItem($this->post->id, $query_type);
-		if ( $this->post->nav_status == 'hide' ) return $this->removeItem($menu_item_id);
-		$menu = $this->syncMenuItem($menu_parent, $menu_item_id);
-		$this->sync( $this->post->id, $menu, $nest_level );
+		if ( $this->nav_menu_repo){
+			$menu_item_id = $this->nav_menu_repo->getMenuItem($this->post->id, $query_type);
+			if ( $this->post->nav_status == 'hide' ) return $this->removeItem($menu_item_id);
+			$menu = $this->syncMenuItem($menu_parent, $menu_item_id);
+			$this->sync( $this->post->id, $menu, $nest_level );
+		}
 	}
 
 	/**


### PR DESCRIPTION
We have a site with a large number of pages (100+). We have decided to move away from using Nested Pages' "Sync menu" option because it takes a long time to sync that large of a menu. However,
1. it seems that Nested Pages is attempting to sync its menu whenever any menu is manually updated and saved, not just the one assigned to Nested Pages
2. it is still attempting to sync the menu when any menu is manually updated, even after that option is disabled.

We have been forced to disable Nested Pages because of these performance issues. But we love the plugin and use it on many sites. Thank you.

I looked into it, and was able to resolve the immediate issue by changing these files. There's probably a better way to do it, but this might get someone in the ballpark.
