### PR TITLE
Fix fatal error in integration with Editorial Access Manager

### DIFF
--- a/app/Entities/PluginIntegration/EditorialAccessManager.php
+++ b/app/Entities/PluginIntegration/EditorialAccessManager.php
@@ -23,6 +23,13 @@ class EditorialAccessManager
 
 	public function __construct()
 	{
+		add_action( 'init', array( $this, 'init' ) );
+	}
+	
+	/**
+	* Initialize Plugin Integration
+	*/
+	public function init() {
 		if ( class_exists('Editorial_Access_Manager') ){
 			$this->installed = true;
 			$this->user = wp_get_current_user();


### PR DESCRIPTION
For further info see [this support topic](https://wordpress.org/support/topic/conflict-with-nested-pages/).

The problem is related to the function wp_get_current_user() not yet loaded when instantiating the EditorialAccessManager class. See further info on [this discussion](http://stackoverflow.com/questions/6127559/wordpress-plugin-call-to-undefined-function-wp-get-current-user).