### PR TITLE
Fix Taxonomy Filtering

### DIFF
--- a/app/Entities/Listing/ListingQuery.php
+++ b/app/Entities/Listing/ListingQuery.php
@@ -80,6 +80,11 @@ class ListingQuery
 			'post_status' => array('publish', 'pending', 'draft', 'private', 'future', 'trash'),
 			'order' => $this->sort_options->order
 		);
+
+		//Add Tax Query if relevant
+		if(isset($this->sort_options->tax_query)):
+			$query_args['tax_query'] = $this->sort_options->tax_query;
+		endif;
 		
 		if ( $this->listing_repo->isSearch() ) $query_args = $this->searchParams($query_args);
 		if ( $this->listing_repo->isFiltered() ) $query_args = $this->filterParams($query_args);


### PR DESCRIPTION
**Issue**

Admin pages were never actually adding the taxonomy query, and thus would not filter at all on any custom taxonomies.

**To Replicate Bug**

Create a Custom Post Type with a Custom Taxonomy.
Configure WP Nested Pages to offer that custom taxonomy as a filter option on the admin view of that custom post type.
Attempt to sort - Nothing will happen.

**Fix**
I added a simple line so that IF a tax filter is present, it will be added back into the WP query, and thus filtering will function again.