### PR TITLE
Allow Recursive Menu Item Deletion

### DIFF
--- a/app/Entities/NavMenu/NavMenuSync.php
+++ b/app/Entities/NavMenu/NavMenuSync.php
@@ -43,12 +43,36 @@ abstract class NavMenuSync
 	}
 
 	/**
-	* Remove a Menu Item
-	* @since 1.3.4
-	* @param int $id - ID of nav menu item
-	*/
-	protected function removeItem($id)
-	{
-		wp_delete_post($id, true);
+	 * Remove a Menu Item
+	 * @since 1.3.4
+	 *
+	 * @param int $id - ID of nav menu item
+	 */
+	protected function removeItem( $id ) {
+
+		$recurse = apply_filters('nestedpages_recursive_remove_menu_item', false, $id);
+		if ( ! empty( $id ) && $recurse ) {
+
+			$args = array(
+				'post_type'  => 'nav_menu_item',
+				'meta_query' => array(
+					array(
+						'key'   => '_menu_item_menu_item_parent',
+						'value' => $id
+					)
+				),
+				'fields'     => 'ids'
+			);
+
+			$children = get_posts( $args );
+
+			if ( $children ) {
+				foreach ( $children as $child ) {
+					$this->removeItem( $child, true );
+				}
+			}
+		}
+
+		wp_delete_post( $id, true );
 	}
 }


### PR DESCRIPTION
When I hide pages I need all of the children to also be removed from the menu.  This seemed like the most straightforward way to do it.