### PR TITLE
adding support for cloning already serialized meta value data

### DIFF
--- a/app/Entities/Post/PostCloner.php
+++ b/app/Entities/Post/PostCloner.php
@@ -110,7 +110,7 @@ class PostCloner
 		$meta = get_post_meta($this->original_id);
 		foreach($meta as $key => $value){
 			foreach( $value as $entry ){
-				add_post_meta($this->new_id, $key, $entry);
+				add_post_meta($this->new_id, $key, maybe_unserialize($entry));
 			}
 		}
 	}


### PR DESCRIPTION
For the post cloning, I wrapped the meta value to be cloned with `maybe_unserialize` function to account for serialized data from plugins like Advanced Custom Fields that store serialized data in meta values.