### PR TITLE
Fix PHP notices for users without role

### DIFF
--- a/app/Entities/AdminCustomization/AdminCustomizationBase.php
+++ b/app/Entities/AdminCustomization/AdminCustomizationBase.php
@@ -57,8 +57,10 @@ abstract class AdminCustomizationBase
 	*/
 	protected function setCurrentUserRoles()
 	{
-		$current_user = wp_get_current_user();
-		$this->current_user_role = $current_user->roles[0];
+        $current_user = wp_get_current_user();
+        if ( isset( $current_user->roles[0] ) ) {
+            $this->current_user_role = $current_user->roles[0];
+        }
 	}
 
 	/**

--- a/app/Entities/AdminCustomization/AdminCustomizationBase.php
+++ b/app/Entities/AdminCustomization/AdminCustomizationBase.php
@@ -57,10 +57,10 @@ abstract class AdminCustomizationBase
 	*/
 	protected function setCurrentUserRoles()
 	{
-        $current_user = wp_get_current_user();
-        if ( isset( $current_user->roles[0] ) ) {
-            $this->current_user_role = $current_user->roles[0];
-        }
+		$current_user = wp_get_current_user();
+		if ( isset( $current_user->roles[0] ) ) {
+			$this->current_user_role = $current_user->roles[0];
+		}
 	}
 
 	/**


### PR DESCRIPTION
Adds a check to make sure the user has a role. I didn't run into any other issues after adding this, but I'm obviously not super familiar with every other place that `$this->current_user_role` is called.

This should resolve #261 



