### PR TITLE
Dedupe "is front page", "is posts page" for plugs

### DIFF
--- a/app/Entities/Listing/Listing.php
+++ b/app/Entities/Listing/Listing.php
@@ -220,10 +220,15 @@ class Listing
 	/**
 	* Get the Post States
 	*/
-	private function postStates()
+	private function postStates($assigned_pt)
 	{
 		$out = '';
-		$post_states = apply_filters('display_post_states', [], $this->post);
+		$post_states = [];
+		if ( !$assigned_pt ) {
+			if ( $this->post->id == get_option('page_on_front') ) $post_states['page_on_front'] = __('Front Page', 'wp-nested-pages');
+			if ( $this->post->id == get_option('page_for_posts') ) $post_states['page_for_posts'] = __('Posts Page', 'wp-nested-pages');
+		}
+		$post_states = apply_filters('display_post_states', $post_states, $this->post);
 		if ( empty($post_states) ) return $out;
 		$state_count = count($post_states);
 		$i = 0;

--- a/app/Views/partials/row.php
+++ b/app/Views/partials/row.php
@@ -29,11 +29,7 @@ if ( !$wpml ) $wpml_pages = true;
 			<span class="title">
 				<?php 
 					echo apply_filters( 'the_title', $this->post->title, $this->post->id, $view = 'nestedpages_title' ); 
-					if ( !$assigned_pt ) :
-						if ( $this->post->id == get_option('page_on_front') ) echo ' <em class="np-page-type"><strong>&ndash; ' . __('Front Page', 'wp-nested-pages') . '</strong></em>';
-						if ( $this->post->id == get_option('page_for_posts') ) echo ' <em class="np-page-type"><strong>&ndash; ' . __('Posts Page', 'wp-nested-pages') . '</strong></em>';
-					endif;
-					echo $this->postStates();
+					echo $this->postStates($assigned_pt);
 				?>
 			</span>
 			<?php 


### PR DESCRIPTION
WP-Admin is using this mechanism to set front page / posts page states, so that plugins (like Polylang) can safely set said flags without having dupe states. (see image)

![upload](https://user-images.githubusercontent.com/668160/64079393-4e9e0000-cce7-11e9-9825-eba565237dc1.png)

Usage in WP-Admin:

https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/template.php#L2079-L2087