### PR TITLE
Move include_link_dropdown check to correct if statement

### DIFF
--- a/app/Views/partials/row.php
+++ b/app/Views/partials/row.php
@@ -136,10 +136,10 @@ if ( !$wpml ) $wpml_pages = true;
 					$include_link_dropdown = ( $this->post_type->name == 'page' ) ? true : false;
 					$include_link_dropdown = apply_filters('nestedpages_include_links_dropdown', $include_link_dropdown, $this->post_type);
 
-					if ( current_user_can('publish_pages') && $this->post_type->hierarchical && !$this->listing_repo->isSearch() && $wpml_pages && $include_link_dropdown) :  
+					if ( current_user_can('publish_pages') && $this->post_type->hierarchical && !$this->listing_repo->isSearch() && $wpml_pages ) :  
 
 					// Link
-					if (!$this->settings->menusDisabled() && !$this->integrations->plugins->wpml->installed && in_array('add_child_link', $this->post_type_settings->row_actions)) : ?>
+					if ( !$this->settings->menusDisabled() && !$this->integrations->plugins->wpml->installed && in_array('add_child_link', $this->post_type_settings->row_actions) && $include_link_dropdown ) : ?>
 					<li>
 						<a href="#" class="open-redirect-modal" data-parentid="<?php echo esc_attr($this->post->id); ?>">
 						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path class="primary" d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>


### PR DESCRIPTION
This pull request fixes issue #270.

The $include_link_dropdown check seems to have been applied to the incorrect if statement when added in commit a4a80c4. It was applied to the if statement that wraps to child if statements for (1) adding child links and (2) adding child pages/custom post types when it should only have been applied to (1).

The result of the bug was that the "Add Child [Custom Post Type]" link was gone.

With this change, the "Add Child [Custom Post Type]" is available for custom post types, but the "Add Child Link" is only available for pages (which seems to be the reason for the change in a4a80c4).