### PR TITLE
fix syncPostOrder to save the parent on every translation

### DIFF
--- a/app/Entities/Listing/Listing.php
+++ b/app/Entities/Listing/Listing.php
@@ -225,8 +225,8 @@ class Listing
 		$out = '';
 		$post_states = [];
 		if ( !$assigned_pt ) {
-			if ( $this->post->id == get_option('page_on_front') ) $post_states['page_on_front'] = __('Front Page', 'wp-nested-pages');
-			if ( $this->post->id == get_option('page_for_posts') ) $post_states['page_for_posts'] = __('Posts Page', 'wp-nested-pages');
+			if ( $this->post->id == get_option('page_on_front') ) $post_states['page_on_front'] = '&ndash; ' . __('Front Page', 'wp-nested-pages');
+			if ( $this->post->id == get_option('page_for_posts') ) $post_states['page_for_posts'] = '&ndash; ' . __('Posts Page', 'wp-nested-pages');
 		}
 		$post_states = apply_filters('display_post_states', $post_states, $this->post);
 		if ( empty($post_states) ) return $out;
@@ -235,7 +235,7 @@ class Listing
 		foreach ( $post_states as $state ) {
 			++$i;
 			( $i == $state_count ) ? $sep = '' : $sep = ', ';
-			$out .= " <em class='np-page-type'><strong>&ndash; $state</strong>$sep</em>";
+			$out .= " <em class='np-page-type'><strong>$state</strong>$sep</em>";
 		}
 		return $out;
 	}

--- a/app/Entities/Listing/Listing.php
+++ b/app/Entities/Listing/Listing.php
@@ -234,7 +234,7 @@ class Listing
 		$i = 0;
 		foreach ( $post_states as $state ) {
 			++$i;
-			( $i == $state_count ) ? $sep = '' : $sep = ', ';
+			( $i == $state_count ) ? $sep = '' : $sep = ',';
 			$out .= " <em class='np-page-type'><strong>$state</strong>$sep</em>";
 		}
 		return $out;

--- a/app/Entities/PluginIntegration/WPML.php
+++ b/app/Entities/PluginIntegration/WPML.php
@@ -128,11 +128,13 @@ class WPML
 		foreach ( $posts as $order => $post ) :
 			$translations = $this->getAllTranslations($post['id']);
 			foreach ( $translations as $lang_code => $post_info ) :
-				$post_id = $post_info->element_id;
-				$query = "UPDATE $wpdb->posts SET menu_order = '$order' WHERE ID = '$post_id'";
-				$wpdb->query( $query );
+				$translation_post_id = $post_info->element_id;
+				$translated_parent = $this->getAllTranslations($post_parent)[$lang_code]->element_id;
+				$query = "UPDATE $wpdb->posts SET menu_order = '$order', post_parent = '$translated_parent' WHERE ID = '$translation_post_id'";
 			endforeach;
-			if ( isset($post['children']) ) $this->syncPostOrder($post['children']);
+            if (isset($post['children'])) :
+                $this->syncPostOrder($post['children'], $post['id']);
+            endif;
 		endforeach;
 	}
 

--- a/app/Entities/Post/PostRepository.php
+++ b/app/Entities/Post/PostRepository.php
@@ -166,7 +166,7 @@ class PostRepository
 	public function getAllTerms($post_id)
 	{
 		global $wpdb;
-		$query = $wpdb->prepare("SELECT p.post_title, tr.term_taxonomy_id AS tax_id, t.slug AS term_name, tt.taxonomy AS tax_name, tt.term_id AS term_id FROM {$wpdb->prefix}posts AS p LEFT JOIN {$wpdb->prefix}term_relationships AS tr ON tr.object_id = p.ID LEFT JOIN {$wpdb->prefix}terms AS t ON t.term_id = tr.term_taxonomy_id LEFT JOIN {$wpdb->prefix}term_taxonomy AS tt ON tt.term_taxonomy_id = tr.term_taxonomy_id WHERE p.ID = %s", $post_id);
+		$query = $wpdb->prepare("SELECT p.post_title, tr.term_taxonomy_id AS tax_id, t.slug AS term_name, tt.taxonomy AS tax_name, tt.term_id AS term_id FROM {$wpdb->prefix}posts AS p INNER JOIN {$wpdb->prefix}term_relationships AS tr ON tr.object_id = p.ID LEFT JOIN {$wpdb->prefix}terms AS t ON t.term_id = tr.term_taxonomy_id LEFT JOIN {$wpdb->prefix}term_taxonomy AS tt ON tt.term_taxonomy_id = tr.term_taxonomy_id WHERE p.ID = %s", $post_id);
 		return $wpdb->get_results($query);
 	}
 


### PR DESCRIPTION
Fix the issue addressed here : https://wordpress.org/support/topic/wpml-translation-sync/

> There seems to be a hitch with the WPML integration.
> 
> I do have two languages activated (French and English) on my website.
> 
> When I move a page in my hierarchy, the menu_order value is saved in both entities (FR and EN), but the post_parent is only persisted in the entity I moved and not the translation.