### PR TITLE
Run the `default_content` hook in createChildPosts

### DIFF
--- a/app/Entities/Post/PostFactory.php
+++ b/app/Entities/Post/PostFactory.php
@@ -65,6 +65,10 @@ class PostFactory
 			if ( isset($data['page_template']) ) $this->post_update_repo->updateTemplate($data);
 			if ( isset($data['nav_status']) ) $this->post_update_repo->updateNavStatus($data);
 			$this->new_ids[$key] = $new_page_id;
+
+			$new_post = get_post($new_page_id);
+			$new_post->post_content = (string) apply_filters('default_content', $new_post->post_content, $new_post);
+			wp_update_post($new_post);
 		}
 		return $this->getNewPosts($post_type);
 	}


### PR DESCRIPTION
This pull request fixes #287.

With this change, the `default_content` filter hook now runs when creating child posts or using the "Add Multiple" pages button, leading to more consistent behavior with the default WordPress "Add new" page behavior.

The change mimics how WordPress Core runs the filter on page creation (line 716): https://core.trac.wordpress.org/browser/tags/5.4/src/wp-admin/includes/post.php#L716

Running the `default_content` filter hook is a no-op if no hooks have been added to it, but is very handy when developers hooks into the filter to provide default content for all pages or certain pages matching various criteria.