### PR TITLE
Added the missing parameter for page_link and post_link hooks

### DIFF
--- a/app/Views/partials/row.php
+++ b/app/Views/partials/row.php
@@ -264,7 +264,7 @@ if ( !$wpml ) $wpml_pages = true;
 			if ( in_array('view', $this->post_type_settings->row_actions) ) : 
 			if ( $this->post->status == 'publish' ) : 
 			$link = apply_filters('nestedpages_view_link', get_the_permalink(), $this->post);
-			$link = ( $this->post_type->name == 'page' ) ? apply_filters('page_link', $link, $this->post->ID) : apply_filters('post_link', $link, $this->post);
+			$link = ( $this->post_type->name == 'page' ) ? apply_filters('page_link', $link, $this->post->ID, false) : apply_filters('post_link', $link, $this->post, false);
 			?>
 			<a href="<?php echo $link; ?>" class="np-btn np-view-button" target="_blank">
 				<?php echo apply_filters('nestedpages_view_link_text', __('View', 'wp-nested-pages'), $this->post); ?>


### PR DESCRIPTION
In WordPress, these two hooks (page_link and post_link) have three parameters each. In the file row.php where these hooks were executed, only two of the parameters were set and the last one was not set.

When another plugin applies a filter to these two hooks and expect 3 parameters, WordPress will throw an error because only two of the required three parameters are set.

This happend for me with the Domain Mapping plugin from WPMU DEV where they have this code:
```
$this->_add_filter("page_link",   'exclude_page_links', 10, 3);
$this->_add_filter("page_link",   'ssl_force_page_links', 11, 3);
```

_`$this->_add_filter()` is in this plugin a 'proxy function' to execute add_filter() from WordPress_

https://developer.wordpress.org/reference/hooks/page_link/
https://developer.wordpress.org/reference/hooks/post_link/