### PR TITLE
Security fix: sanitize page template data

### DIFF
--- a/app/Entities/Listing/Listing.php
+++ b/app/Entities/Listing/Listing.php
@@ -419,7 +419,7 @@ class Listing
 
 				// CSS Classes for the <li> row element
 				$template = ( $this->post->template )
-					? ' tpl-' .  str_replace('.php', '', $this->post->template)
+					? ' tpl-' .  str_replace('.php', '', sanitize_html_class( $this->post->template ) )
 					: '';
 
 				$row_classes = '';


### PR DESCRIPTION
Security enhancement preventing XSS with unsafe data in `_wp_page_template` postmeta.

I have experienced hacking in my website, using this post meta, and Nested Pages allows javascript to be executed in the backend.

Thank you