### PR TITLE
Fixed Add Link saving links with missing fields

### DIFF
--- a/app/Entities/Post/PostUpdateRepository.php
+++ b/app/Entities/Post/PostUpdateRepository.php
@@ -481,6 +481,7 @@ class PostUpdateRepository
 			$new_link['post_content'] = esc_url($data['url']);
 		}
 		$this->new_id = wp_insert_post($new_link);
+		$data['post_id'] = $this->new_id;
 		$parent_post_type = ( isset($data['parent_post_type']) ) ? sanitize_text_field($data['parent_post_type']) : 'page';
 		add_post_meta($this->new_id, '_np_parent_post_type', $parent_post_type);
 		$this->updateMenuMeta($data);


### PR DESCRIPTION
Add Link on admin.php?page=nestedpages creates np-redirects with most meta fields missing. The permission check fails in PostUpdateRepository::updateMenuMeta. $data['post_id'] isn't set so the permissions check current_user_can( 'edit_post', null ) fails.