### PR TITLE
Fixing the Uncaught TypeError in ListingRepository.php when using PHP 8

### DIFF
--- a/app/Entities/Listing/ListingRepository.php
+++ b/app/Entities/Listing/ListingRepository.php
@@ -37,7 +37,10 @@ class ListingRepository
 		$meta = get_user_meta(get_current_user_id(), 'np_visible_posts', true);
 		if ( $meta == '1' ) return [];
 		$visible = unserialize($meta);
-		if ( !$visible || !isset($visible[$post_type]) ) $visible[$post_type] = [];
+		if ( !$visible || !isset($visible[$post_type]) ) {
+				$visible= array();
+				$visible[$post_type] = [];
+		}
 		return $visible[$post_type];
 	}
 


### PR DESCRIPTION
Uncaught TypeError: Cannot access offset of type string on string in /wp-content/plugins/wp-nested-pages/app/Entities/Listing/ListingRepository.php