### PR TITLE
First commit: Make bulk actions configurable

### DIFF
--- a/app/Config/Settings.php
+++ b/app/Config/Settings.php
@@ -99,6 +99,7 @@ class Settings
 		register_setting( 'nestedpages-general', 'nestedpages_ui' );
 		register_setting( 'nestedpages-general', 'nestedpages_allowsorting' );
 		register_setting( 'nestedpages-general', 'nestedpages_allowsortview' );
+		register_setting( 'nestedpages-general', 'nestedpages_allowbulkactions' );
 		register_setting( 'nestedpages-posttypes', 'nestedpages_posttypes' );
 		register_setting( 'nestedpages-admincustomization', 'nestedpages_admin' );
 	}

--- a/app/Config/SettingsRepository.php
+++ b/app/Config/SettingsRepository.php
@@ -211,7 +211,8 @@ class SettingsRepository
 			'nestedpages_posttypes',
 			'nestedpages_ui',
 			'nestedpages_version',
-			'nestedpages_admin'
+			'nestedpages_admin',
+			'nestedpages_allowbulkactions',
 		];
 		foreach($options as $option){
 			delete_option($option);
@@ -262,4 +263,17 @@ class SettingsRepository
 		endif;
 		return $roles;
 	}
+
+	/**
+	 * Bulk Actions enabled
+	 * @return array of role names
+	 */
+	public function bulkActionsEnabled() {
+		$roles = get_option('nestedpages_allowbulkactions', false);
+
+		// If the option hasn't been saved yet, fall back to all
+		if ( !is_array($roles) ) $roles = array_keys(wp_roles()->roles);
+		return $roles;
+	}
+
 }

--- a/app/Entities/Listing/Listing.php
+++ b/app/Entities/Listing/Listing.php
@@ -128,6 +128,11 @@ class Listing
 	private $status_preference;
 
 	/**
+	 * User can perform bulk actions
+	 */
+	private $can_user_perform_bulk_actions;
+
+	/**
 	* Enabled Custom Fields
 	*/
 	private $enabled_custom_fields;
@@ -150,6 +155,7 @@ class Listing
 		$this->setPostTypeSettings();
 		$this->setStandardFields();
 		$this->setStatusPreference();
+		$this->setCanUserPerformBulkActions();
 	}
 
 	/**
@@ -290,6 +296,13 @@ class Listing
 	}
 
 	/**
+	 * Set if the user can perform bulk actions
+	 */
+	private function setCanUserPerformBulkActions() {
+		$this->can_user_perform_bulk_actions = $this->user->canPerformBulkActions();
+	}
+
+	/**
 	* Set the user status preference
 	*/
 	private function setStatusPreference()
@@ -326,8 +339,10 @@ class Listing
 
 		// Primary List
 		if ( $count == 0 ) {
-			include( Helpers::view('partials/list-header') ); // List Header
-			include( Helpers::view('partials/bulk-edit') ); // Bulk Edit
+			if ( $this->can_user_perform_bulk_actions ) {
+				include( Helpers::view('partials/list-header') ); // List Header
+				include( Helpers::view('partials/bulk-edit') ); // Bulk Edit
+			}
 			echo '<ol class="' . $list_classes . '" id="np-' . $this->post_type->name . '">';
 			return;
 		}

--- a/app/Entities/User/UserRepository.php
+++ b/app/Entities/User/UserRepository.php
@@ -161,6 +161,21 @@ class UserRepository
 	}
 
 	/**
+	 * Can the user perform bulk actions?
+	 */
+	public function canPerformBulkActions() {
+		$allowed_roles = $this->settings->bulkActionsEnabled();
+		$allowed = false;
+		foreach ( $allowed_roles as $allowed_role ) {
+			if ( current_user_can($allowed_role) ) {
+				$allowed = true;
+				break;  // optimization
+			}
+		}
+		return $allowed;
+	}
+
+	/**
 	* Get an array of all users/ids
 	* @since 1.3.0
 	* @return array

--- a/app/Views/partials/row-link.php
+++ b/app/Views/partials/row-link.php
@@ -109,9 +109,10 @@ endif;
 		$out .= '</div>';
 		echo $out;
 	endif;
-	?>
 
+	if ( $this->can_user_perform_bulk_actions ) : ?>
 	<div class="np-bulk-checkbox">
 		<input type="checkbox" name="nestedpages_bulk[]" value="<?php echo esc_attr($this->post->id); ?>" data-np-bulk-checkbox="<?php echo esc_attr($this->post->title); ?>" class="np-redirect-bulk" data-np-post-type="<?php echo esc_attr($this->post->post_type); ?>" />
 	</div>
+	<?php endif ?>
 </div><!-- .row -->

--- a/app/Views/partials/row.php
+++ b/app/Views/partials/row.php
@@ -319,9 +319,10 @@ if ( !$wpml ) $wpml_pages = true;
 		$out .= '</div>';
 		echo $out;
 	endif;
-	?>
 
+	if ( $this->can_user_perform_bulk_actions ) : ?>
 	<div class="np-bulk-checkbox">
 		<input type="checkbox" name="nestedpages_bulk[]" value="<?php echo esc_attr($this->post->id); ?>" data-np-bulk-checkbox="<?php echo esc_attr($this->post->title); ?>" data-np-post-type="<?php echo esc_attr($this->post->post_type); ?>" />
 	</div>
+	<?php endif ?>
 </div><!-- .row -->

--- a/app/Views/settings/settings-general.php
+++ b/app/Views/settings/settings-general.php
@@ -3,6 +3,7 @@ $allowsorting = get_option('nestedpages_allowsorting', []);
 $allowsortview = $this->settings->sortViewEnabled();
 if ( $allowsorting == "" ) $allowsorting = [];
 $sync_status = ( $this->settings->menuSyncEnabled() ) ? __('Currently Enabled', 'wp-nested-pages') : __('Currently Disabled', 'wp-nested-pages');
+$bulkActionsEnabled = $this->settings->bulkActionsEnabled();
 ?>
 <div class="nestedpages-settings-general-wrapper">
 	<div class="nestedpages-settings-table">
@@ -118,6 +119,24 @@ $sync_status = ( $this->settings->menuSyncEnabled() ) ? __('Currently Enabled', 
 					<br />
 					<?php endforeach; ?>
 					<p><em><?php _e('Admins may always view the sort view.', 'wp-nested-pages'); ?></em></p>
+				</div>
+			</div><!-- .row -->
+
+			<div class="row">
+				<div class="description">
+					<p><strong><?php _e('Allow Bulk Actions', 'wp-nested-pages'); ?></strong></p>
+				</div>
+				<div class="field">
+					<?php foreach ( $this->user_repo->allRoles([]) as $role ) : ?>
+					<label>
+						<?php
+						$checked = in_array($role['name'], $bulkActionsEnabled);
+						?>
+						<input type="checkbox" name="nestedpages_allowbulkactions[]" value="<?= $role['name'] ?>" <?php if ( $checked ) echo 'checked'; ?>>
+						<?= esc_html($role['label']); ?>
+					</label>
+					<br>
+					<?php endforeach; ?>
 				</div>
 			</div><!-- .row -->
 


### PR DESCRIPTION
Dear Kyle,

this is another modification proposed by us, i.e. the PLUS. This is to make the availability of bulk actions configurable.

Please note that this modification is incompatible with the original version, because newly added roles do not have the permission to perform bulk actions. I wanted to make this compatible, but I notices that this would require some JavaScript code. Once I get Gulp running, this may be an option for me to implement.

Kind regards,
Robert.