### PR TITLE
Delete post cache on update

### DIFF
--- a/app/Entities/Post/PostUpdateRepository.php
+++ b/app/Entities/Post/PostUpdateRepository.php
@@ -96,7 +96,8 @@ class PostUpdateRepository
 			$wpdb->query( $query );
 			do_action('nestedpages_post_order_updated', $post_id, $parent, $key, $filtered);
 
-			do_action('nestedpages_post_order_updated', $post_id, $parent, $key, $filtered);
+			wp_cache_delete( $post_id, 'posts' );
+			
 			if ( isset($post['children']) ) $this->updateOrder($post['children'], $post_id);
 		}
 		do_action('nestedpages_posts_order_updated', $posts, $parent);


### PR DESCRIPTION
WordPress 6.3+ relies more heavily on object cache. If you update pages order with the plugin, and then edit a page, the "order" attribute on the "Page Attributes" field will have the value prior to updating the order with the plugin. You can also check this using wp-cli.

Deleting the post from object cache will avoid the stale data.