### PR TITLE
Add custom post type templates selection support

### DIFF
--- a/app/Views/forms/new-child.php
+++ b/app/Views/forms/new-child.php
@@ -72,7 +72,13 @@
 			<label><?php _e( 'Template' ); ?></label>
 			<select name="page_template" class="np_template">
 				<option value="default"><?php _e( 'Default Template' ); ?></option>
-				<?php page_template_dropdown() ?>
+				<?php 
+          if( is_page() ){
+            page_template_dropdown();
+          }else{
+            page_template_dropdown('', $this->post_type->name);
+          }
+          ?>
 			</select>
 		</div>
 		<?php endif; ?>

--- a/app/Views/forms/quickedit-post.php
+++ b/app/Views/forms/quickedit-post.php
@@ -136,7 +136,13 @@ $has_menu_options = ( $this->user->canSortPosts($this->post_type->name) && $this
 				<label><?php _e( 'Template' ); ?></label>
 				<select name="page_template" class="np_template">
 					<option value="default"><?php _e( 'Default Template' ); ?></option>
-					<?php page_template_dropdown() ?>
+					<?php 
+          if( is_page() ){
+            page_template_dropdown();
+          }else{
+            page_template_dropdown('', $this->post_type->name);
+          }
+          ?>
 				</select>
 			</div>
 			<?php endif; ?>

--- a/app/Views/partials/bulk-edit.php
+++ b/app/Views/partials/bulk-edit.php
@@ -62,7 +62,13 @@ $has_menu_options = ( $this->user->canSortPosts($this->post_type->name) && $this
 					<select name="page_template">
 						<option value="">&mdash; <?php _e('No Change', 'wp-nested-pages'); ?> &mdash;</option>
 						<option value="default"><?php _e( 'Default Template', 'wp-nested-pages' ); ?></option>
-						<?php page_template_dropdown() ?>
+						<?php 
+              if( is_page() ){
+                page_template_dropdown();
+              }else{
+                page_template_dropdown('', $this->post_type->name);
+              }
+            ?>
 					</select>
 				</div>
 				<?php endif; ?>


### PR DESCRIPTION
Adding the ability to select a post type template in a hierachical post type section rather than a page template when quick edit,  add or bulk edit.