### PR TITLE
Fix phpdoc for nestedpages_sorting_capability filter

### DIFF
--- a/app/Entities/User/UserCapabilities.php
+++ b/app/Entities/User/UserCapabilities.php
@@ -40,9 +40,9 @@ class UserCapabilities
 				 *
 				 * @since 3.1.9
 				 *
-				 * @param bool  $grant_role     Whether role may sort post type.
-				 * @param string $type 			The post type name.
-				 * @param string  $role_name	The Role Name.
+				 * @param bool $grant_role Whether role may sort post type.
+				 * @param string $type     The post type name.
+				 * @param \WP_Role $role   The role object.
 				 */
 				$grant_capability = apply_filters("nestedpages_sorting_capability", $grant_capability, $type, $role);
 				if ( $grant_capability ) $role->add_cap("nestedpages_sorting_$type", true);

--- a/app/Entities/User/UserCapabilities.php
+++ b/app/Entities/User/UserCapabilities.php
@@ -40,9 +40,9 @@ class UserCapabilities
 				 *
 				 * @since 3.1.9
 				 *
-				 * @param bool $grant_role Whether role may sort post type.
-				 * @param string $type     The post type name.
-				 * @param \WP_Role $role   The role object.
+				 * @param bool $grant_capability Whether role may sort post type.
+				 * @param string $type           The post type name.
+				 * @param \WP_Role $role         The role object.
 				 */
 				$grant_capability = apply_filters("nestedpages_sorting_capability", $grant_capability, $type, $role);
 				if ( $grant_capability ) $role->add_cap("nestedpages_sorting_$type", true);


### PR DESCRIPTION
Corrects the phpdoc for the `nestedpages_sorting_capability`. I've also tidied up the whitespace for the comment.

Currently this causes issues in static analysis tools like phpstan.